### PR TITLE
fix(type): Correct start signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace fastifyasyncforge {
   export function request<T extends FastifyRequest>(): T;
   export function reply<T extends FastifyReply>(): T;
   export function logger<T extends FastifyBaseLogger>(): T;
-  export function start<T extends FastifyInstance>(): Promise<T>;
+  export function start(app: FastifyInstance): Promise<void>;
 }
 
 declare function fastifyasyncforge(): FastifyPluginCallback;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -48,4 +48,6 @@ expectError<FastifyBaseLogger>(logger<object>());
 expectError<FastifyBaseLogger>({});
 
 // start
-expectType<Promise<FastifyInstance>>(start());
+expectType<void>(await start(fastifyInstance));
+expectError<void>(await start({ invalid: "object" }));
+expectError<void>(await start());


### PR DESCRIPTION
`start` should require a `FastifyInstance`