### PR TITLE
fix(types): Remove start method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,8 +8,8 @@ import {
 
 declare module "fastify" {
   interface FastifyInstance {
-    runInAsyncScope<T> (fn: () => T) : T;
-    enterWith() : void
+    runInAsyncScope<T>(fn: () => T): T;
+    enterWith(): void;
   }
 }
 
@@ -18,7 +18,6 @@ declare namespace fastifyasyncforge {
   export function request<T extends FastifyRequest>(): T;
   export function reply<T extends FastifyReply>(): T;
   export function logger<T extends FastifyBaseLogger>(): T;
-  export function start(app: FastifyInstance): Promise<void>;
 }
 
 declare function fastifyasyncforge(): FastifyPluginCallback;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -48,8 +48,3 @@ expectType<void>(logger().info({ msg: "oh!" }));
 expectType<void>(logger().warn({ msg: "let's go!!!" }));
 expectError<FastifyBaseLogger>(logger<object>());
 expectError<FastifyBaseLogger>({});
-
-// start
-expectType<void>(await start(fastifyInstance));
-expectError<void>(await start({ invalid: "object" }));
-expectError<void>(await start());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError, expectType } from "tsd";
-import fastifyasyncforge, { app, logger, reply, request, start } from ".";
+import fastifyasyncforge, { app, logger, reply, request } from ".";
 import fastify, {
   type FastifyInstance,
   type FastifyBaseLogger,


### PR DESCRIPTION
We should remove `start` method from types since it's no longer available and it can be misleading